### PR TITLE
Implement delta-based + state-driven & digest-driven algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ldb
+# ldb 
 
 [![Build Status](https://travis-ci.org/vitorenesduarte/ldb.svg?branch=master)](https://travis-ci.org/vitorenesduarte/ldb/)
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -6,7 +6,7 @@
  {<<"lager">>,{pkg,<<"lager">>,<<"3.2.4">>},0},
  {<<"partisan">>,
   {git,"https://github.com/lasp-lang/partisan",
-       {ref,"85a4ba49588b09a51836872753669b5e7f360736"}},
+       {ref,"5b929d260d1bf1ae0545259a9ce61811da26fb16"}},
   0},
  {<<"rand_compat">>,{pkg,<<"rand_compat">>,<<"0.0.1">>},0},
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -12,7 +12,7 @@
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0},
  {<<"types">>,
   {git,"https://github.com/lasp-lang/types",
-       {ref,"701b03ad9c0b94dfe1174b06914233b00f4a3bf4"}},
+       {ref,"9559759859f8aed461342576443295c38044bcf4"}},
   0}]}.
 [
 {pkg_hash,[

--- a/rebar.lock
+++ b/rebar.lock
@@ -7,7 +7,7 @@
  {<<"partisan">>,{pkg,<<"partisan">>,<<"0.2.1">>},0},
  {<<"rand_compat">>,{pkg,<<"rand_compat">>,<<"0.0.1">>},0},
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0},
- {<<"types">>,{pkg,<<"types">>,<<"0.1.4">>},0}]}.
+ {<<"types">>,{pkg,<<"types">>,<<"0.1.6">>},0}]}.
 [
 {pkg_hash,[
  {<<"acceptor_pool">>, <<"679D741DF87FC13599B1AEF2DF8F78F1F880449A6BEFAB7C44FB6FAE0E92A2DE">>},
@@ -18,5 +18,5 @@
  {<<"partisan">>, <<"0B9A791F23EA5E71BD3D5679DC86B219282BBC4E768E71FC3FD8762AA67F134F">>},
  {<<"rand_compat">>, <<"624B590931D27252D0BCF710211699DB3695540706F57D2E91B918A17AB58839">>},
  {<<"time_compat">>, <<"23FE0AD1FDF3B5B88821B2D04B4B5E865BF587AE66056D671FE0F53514ED8139">>},
- {<<"types">>, <<"35A159D185FFB83ACAA2EF73B6511E3BC93537DC5616293240D94A4163D2B66D">>}]}
+ {<<"types">>, <<"03BB7140016C896D3441A77CB0B7D6ACAA583D6D6E9C4A3E1FD3C25123710290">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -12,7 +12,7 @@
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0},
  {<<"types">>,
   {git,"https://github.com/lasp-lang/types",
-       {ref,"1385e60eea0d73b88f560ac7a54aee0b697e34c5"}},
+       {ref,"914ca18e9d89f160f1dea89edc91e47ba68c539c"}},
   0}]}.
 [
 {pkg_hash,[

--- a/rebar.lock
+++ b/rebar.lock
@@ -12,7 +12,7 @@
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0},
  {<<"types">>,
   {git,"https://github.com/lasp-lang/types",
-       {ref,"9559759859f8aed461342576443295c38044bcf4"}},
+       {ref,"1385e60eea0d73b88f560ac7a54aee0b697e34c5"}},
   0}]}.
 [
 {pkg_hash,[

--- a/rebar.lock
+++ b/rebar.lock
@@ -10,7 +10,10 @@
   0},
  {<<"rand_compat">>,{pkg,<<"rand_compat">>,<<"0.0.1">>},0},
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0},
- {<<"types">>,{pkg,<<"types">>,<<"0.1.6">>},0}]}.
+ {<<"types">>,
+  {git,"https://github.com/lasp-lang/types",
+       {ref,"701b03ad9c0b94dfe1174b06914233b00f4a3bf4"}},
+  0}]}.
 [
 {pkg_hash,[
  {<<"acceptor_pool">>, <<"679D741DF87FC13599B1AEF2DF8F78F1F880449A6BEFAB7C44FB6FAE0E92A2DE">>},
@@ -19,6 +22,5 @@
  {<<"jsx">>, <<"749BEC6D205C694AE1786D62CEA6CC45A390437E24835FD16D12D74F07097727">>},
  {<<"lager">>, <<"A6DEB74DAE7927F46BD13255268308EF03EB206EC784A94EAF7C1C0F3B811615">>},
  {<<"rand_compat">>, <<"624B590931D27252D0BCF710211699DB3695540706F57D2E91B918A17AB58839">>},
- {<<"time_compat">>, <<"23FE0AD1FDF3B5B88821B2D04B4B5E865BF587AE66056D671FE0F53514ED8139">>},
- {<<"types">>, <<"03BB7140016C896D3441A77CB0B7D6ACAA583D6D6E9C4A3E1FD3C25123710290">>}]}
+ {<<"time_compat">>, <<"23FE0AD1FDF3B5B88821B2D04B4B5E865BF587AE66056D671FE0F53514ED8139">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,10 @@
  {<<"ishikawa">>,{pkg,<<"ishikawa">>,<<"0.0.2">>},0},
  {<<"jsx">>,{pkg,<<"jsx">>,<<"2.8.0">>},0},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.2.4">>},0},
- {<<"partisan">>,{pkg,<<"partisan">>,<<"0.2.1">>},0},
+ {<<"partisan">>,
+  {git,"https://github.com/lasp-lang/partisan",
+       {ref,"85a4ba49588b09a51836872753669b5e7f360736"}},
+  0},
  {<<"rand_compat">>,{pkg,<<"rand_compat">>,<<"0.0.1">>},0},
  {<<"time_compat">>,{pkg,<<"time_compat">>,<<"0.0.1">>},0},
  {<<"types">>,{pkg,<<"types">>,<<"0.1.6">>},0}]}.
@@ -15,7 +18,6 @@
  {<<"ishikawa">>, <<"367DC326DF3A2C66C68A6C221A0991BB0398F3B43DF27A55A599AEDE97409B3A">>},
  {<<"jsx">>, <<"749BEC6D205C694AE1786D62CEA6CC45A390437E24835FD16D12D74F07097727">>},
  {<<"lager">>, <<"A6DEB74DAE7927F46BD13255268308EF03EB206EC784A94EAF7C1C0F3B811615">>},
- {<<"partisan">>, <<"0B9A791F23EA5E71BD3D5679DC86B219282BBC4E768E71FC3FD8762AA67F134F">>},
  {<<"rand_compat">>, <<"624B590931D27252D0BCF710211699DB3695540706F57D2E91B918A17AB58839">>},
  {<<"time_compat">>, <<"23FE0AD1FDF3B5B88821B2D04B4B5E865BF587AE66056D671FE0F53514ED8139">>},
  {<<"types">>, <<"03BB7140016C896D3441A77CB0B7D6ACAA583D6D6E9C4A3E1FD3C25123710290">>}]}

--- a/src/ldb_delta_based_backend.erl
+++ b/src/ldb_delta_based_backend.erl
@@ -332,7 +332,7 @@ memory() ->
 init([]) ->
     {ok, _Pid} = ldb_store:start_link(),
     Actor = ldb_config:id(),
-    
+
     schedule_dbuffer_shrink(),
 
     ?LOG("ldb_delta_based_backend initialized!"),

--- a/src/ldb_delta_based_backend.erl
+++ b/src/ldb_delta_based_backend.erl
@@ -350,7 +350,7 @@ init([]) ->
                 keys_to_shrink=ordsets:new()}}.
 
 handle_call({create, Key, LDBType}, _From, State) ->
-    %ldb_util:qs("DELTA BACKEND create"),
+    ldb_util:qs("DELTA BACKEND create"),
     Bottom = ldb_util:new_crdt(type, LDBType),
     Default = get_entry(Bottom),
 
@@ -363,7 +363,7 @@ handle_call({create, Key, LDBType}, _From, State) ->
     {reply, Result, State};
 
 handle_call({query, Key}, _From, State) ->
-    %ldb_util:qs("DELTA BACKEND query"),
+    ldb_util:qs("DELTA BACKEND query"),
     Result = case ldb_store:get(Key) of
         {ok, {{Type, _}=CRDT, _, _, _}} ->
             {ok, Type:query(CRDT)};
@@ -374,7 +374,7 @@ handle_call({query, Key}, _From, State) ->
     {reply, Result, State};
 
 handle_call({update, Key, Operation}, _From, #state{actor=Actor}=State) ->
-    %ldb_util:qs("DELTA BACKEND update"),
+    ldb_util:qs("DELTA BACKEND update"),
     Function = fun({{Type, _}=CRDT0, Sequence, DeltaBuffer0, AckMap}) ->
         case Type:delta_mutate(Operation, Actor, CRDT0) of
             {ok, Delta} ->
@@ -391,7 +391,7 @@ handle_call({update, Key, Operation}, _From, #state{actor=Actor}=State) ->
     {reply, Result, State};
 
 handle_call(memory, _From, State) ->
-    %ldb_util:qs("DELTA BACKEND memory"),
+    ldb_util:qs("DELTA BACKEND memory"),
     FoldFunction = fun({_Key, Value}, {C, R}) ->
         {CRDT, Sequence, DeltaBuffer, AckMap} = Value,
         CRDTSize = ldb_util:size(crdt, CRDT),
@@ -408,11 +408,11 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast({add_key_to_shrink, Key}, #state{keys_to_shrink=Keys}=State) ->
-    %ldb_util:qs("DELTA BACKEND add_key_to_shrink"),
+    ldb_util:qs("DELTA BACKEND add_key_to_shrink"),
     {noreply, State#state{keys_to_shrink=ordsets:add_element(Key, Keys)}};
 
 handle_cast(dbuffer_shrink, #state{keys_to_shrink=Keys}=State) ->
-    %ldb_util:qs("DELTA BACKEND dbuffer_shrink"),
+    ldb_util:qs("DELTA BACKEND dbuffer_shrink"),
     case ordsets:size(Keys) > 0 of
         true ->
             Peers = ldb_whisperer:members(),

--- a/src/ldb_delta_based_backend.erl
+++ b/src/ldb_delta_based_backend.erl
@@ -75,7 +75,7 @@ message_maker() ->
                         ShouldStart = Actor < NodeName,
 
                         Mode = ldb_config:get(ldb_driven_mode),
-                        
+
                         case Mode of
                             none ->
                                 Message = {
@@ -90,27 +90,27 @@ message_maker() ->
                                 case ShouldStart of
                                     true ->
                                         %% compute bottom
-																				Bottom = ldb_util:new_crdt(state, CRDT),
+                                        Bottom = ldb_util:new_crdt(state, CRDT),
 
-																				%% compute digest
-																				Digest = case Mode of
-																						state_driven ->
-																								{state, CRDT};
-																						digest_driven ->
-																								%% this can still be a CRDT state
-																								%% if implemented like that
-																								%% by the data type
-																								Type:digest(CRDT)
-																				end,
+                                        %% compute digest
+                                        Digest = case Mode of
+                                            state_driven ->
+                                                {state, CRDT};
+                                            digest_driven ->
+                                                %% this can still be a CRDT state
+                                                %% if implemented like that
+                                                %% by the data type
+                                                Type:digest(CRDT)
+                                        end,
 
-																				Message = {
-																						Key,
-																						digest,
-																						Actor,
+                                        Message = {
+                                            Key,
+                                            digest,
+                                            Actor,
                                             Sequence,
-																						Bottom,
-																						Digest
-																				},
+                                            Bottom,
+                                            Digest
+                                        },
 
                                         {Message, AckMap0};
                                     false ->
@@ -293,10 +293,10 @@ message_handler({_, digest, _, _, _, _}) ->
 
         ldb_whisperer:send(From, ToSend)
     end;
-message_handler({_, digest_and_state, _, _, _, _}) -> 
+message_handler({_, digest_and_state, _, _, _, _}) ->
     fun({Key, digest_and_state, From, RemoteSequence,
          {Type, _}=RemoteDelta, RemoteDigest}) ->
-            
+
         {ok, {LocalCRDT, LocalSequence, _, _}} = ldb_store:get(Key),
         Actor = ldb_config:id(),
 
@@ -314,15 +314,15 @@ message_handler({_, digest_and_state, _, _, _, _}) ->
         %% send delta
         ldb_whisperer:send(From, Message),
 
-				FakeMessage = {
-						Key,
-						delta,
-						From,
-						RemoteSequence,
-						RemoteDelta
-				},
-				Handler = message_handler(FakeMessage),
-				Handler(FakeMessage)
+        FakeMessage = {
+            Key,
+            delta,
+            From,
+            RemoteSequence,
+            RemoteDelta
+        },
+        Handler = message_handler(FakeMessage),
+        Handler(FakeMessage)
     end.
 
 -spec memory() -> {non_neg_integer(), non_neg_integer()}.

--- a/src/ldb_delta_based_backend.erl
+++ b/src/ldb_delta_based_backend.erl
@@ -217,7 +217,9 @@ message_handler({_, delta, _, _, _}) ->
                     ldb_config:id(),
                     N
                 },
+                ?LOG("S: SEND delta"),
                 ldb_whisperer:send(From, Ack),
+                ?LOG("E: SEND delta"),
 
                 StoreValue = {Merged, Sequence, DeltaBuffer, AckMap},
                 {ok, StoreValue}

--- a/src/ldb_delta_based_backend.erl
+++ b/src/ldb_delta_based_backend.erl
@@ -402,11 +402,12 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast({dbuffer_shrink, Key}, State) ->
+    lager:info("ASKING MEMBERS TO WHISPERER"),
+    Peers = ldb_whisperer:members(),
+    lager:info("DONE ASKING MEMBERS TO WHISPERER"),
+
     ShrinkFun = fun({LocalCRDT, Sequence, DeltaBuffer0, AckMap0}) ->
 
-        lager:info("ASKING MEMBERS TO WHISPERER"),
-        Peers = ldb_whisperer:members(),
-        lager:info("DONE ASKING MEMBERS TO WHISPERER"),
 
         %% only keep in the ack map entries from current peers
         AckMap1 = [Entry || {Peer, _}=Entry <- AckMap0, lists:member(Peer, Peers)],

--- a/src/ldb_delta_based_backend.erl
+++ b/src/ldb_delta_based_backend.erl
@@ -383,9 +383,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast({dbuffer_shrink, Key}, State) ->
-    lager:info("ASKING MEMBERS TO WHISPERER"),
     Peers = ldb_whisperer:members(),
-    lager:info("DONE ASKING MEMBERS TO WHISPERER"),
 
     ShrinkFun = fun({LocalCRDT, Sequence, DeltaBuffer0, AckMap0}) ->
 

--- a/src/ldb_delta_based_backend.erl
+++ b/src/ldb_delta_based_backend.erl
@@ -64,7 +64,6 @@ update(Key, Operation) ->
 -spec message_maker() -> function().
 message_maker() ->
     fun(Key, {{Type, _}=CRDT, Sequence, DeltaBuffer, AckMap0}=Value, NodeName) ->
-        ?LOG("- MESSAGE MAKER"),
         Actor = ldb_config:id(),
         MinSeq = min_seq_buffer(DeltaBuffer),
         {LastAck, _} = last_ack(NodeName, AckMap0),
@@ -165,8 +164,6 @@ message_maker() ->
                 {nothing, Value}
         end,
 
-        ?LOG("+ MESSAGE MAKER"),
-
         Result
     end.
 
@@ -174,7 +171,6 @@ message_maker() ->
 message_handler({_, delta, _, _, _}) ->
     fun({Key, delta, From, N, {Type, _}=RemoteCRDT}) ->
 
-        ?LOG("- MESSAGE HANDLER delta"),
         %% create bottom entry
         Bottom = ldb_util:new_crdt(state, RemoteCRDT),
         Default = get_entry(Bottom),
@@ -217,20 +213,16 @@ message_handler({_, delta, _, _, _}) ->
                     ldb_config:id(),
                     N
                 },
-                ?LOG("- SEND delta"),
                 ldb_whisperer:send(From, Ack),
-                ?LOG("+ SEND delta"),
 
                 StoreValue = {Merged, Sequence, DeltaBuffer, AckMap},
                 {ok, StoreValue}
             end,
             Default
-        ),
-        ?LOG("+ MESSAGE HANDLER delta")
+        )
     end;
 message_handler({_, delta_ack, _, _}) ->
     fun({Key, delta_ack, From, N}) ->
-        ?LOG("- MESSAGE HANDLER delta_ack"),
         ldb_store:update(
             Key,
             fun({LocalCRDT, Sequence, DeltaBuffer, AckMap0}) ->
@@ -253,13 +245,11 @@ message_handler({_, delta_ack, _, _}) ->
             end
         ),
 
-        add_key_to_shrink(Key),
+        add_key_to_shrink(Key)
 
-        ?LOG("+ MESSAGE HANDLER delta_ack")
     end;
 message_handler({_, digest, _, _, _, _}) ->
     fun({Key, digest, From, RemoteSequence, {Type, _}=Bottom, Remote}) ->
-        ?LOG("- MESSAGE HANDLER digest"),
         Default = get_entry(Bottom),
         ldb_store:update(
             Key,
@@ -309,15 +299,12 @@ message_handler({_, digest, _, _, _, _}) ->
                 }
         end,
 
-        ldb_whisperer:send(From, ToSend),
-
-        ?LOG("+ MESSAGE HANDLER digest")
+        ldb_whisperer:send(From, ToSend)
     end;
 message_handler({_, digest_and_state, _, _, _, _}) ->
     fun({Key, digest_and_state, From, RemoteSequence,
          {Type, _}=RemoteDelta, RemoteDigest}) ->
 
-        ?LOG("- MESSAGE HANDLER digest_and_state"),
         {ok, {LocalCRDT, LocalSequence, _, _}} = ldb_store:get(Key),
         Actor = ldb_config:id(),
 
@@ -343,9 +330,8 @@ message_handler({_, digest_and_state, _, _, _, _}) ->
             RemoteDelta
         },
         Handler = message_handler(FakeMessage),
-        Handler(FakeMessage),
+        Handler(FakeMessage)
 
-        ?LOG("+ MESSAGE HANDLER digest_and_state")
     end.
 
 -spec memory() -> {non_neg_integer(), non_neg_integer()}.
@@ -364,7 +350,7 @@ init([]) ->
                 keys_to_shrink=ordsets:new()}}.
 
 handle_call({create, Key, LDBType}, _From, State) ->
-    ldb_util:qs("DELTA BACKEND create"),
+    %ldb_util:qs("DELTA BACKEND create"),
     Bottom = ldb_util:new_crdt(type, LDBType),
     Default = get_entry(Bottom),
 
@@ -377,7 +363,7 @@ handle_call({create, Key, LDBType}, _From, State) ->
     {reply, Result, State};
 
 handle_call({query, Key}, _From, State) ->
-    ldb_util:qs("DELTA BACKEND query"),
+    %ldb_util:qs("DELTA BACKEND query"),
     Result = case ldb_store:get(Key) of
         {ok, {{Type, _}=CRDT, _, _, _}} ->
             {ok, Type:query(CRDT)};
@@ -388,7 +374,7 @@ handle_call({query, Key}, _From, State) ->
     {reply, Result, State};
 
 handle_call({update, Key, Operation}, _From, #state{actor=Actor}=State) ->
-    ldb_util:qs("DELTA BACKEND update"),
+    %ldb_util:qs("DELTA BACKEND update"),
     Function = fun({{Type, _}=CRDT0, Sequence, DeltaBuffer0, AckMap}) ->
         case Type:delta_mutate(Operation, Actor, CRDT0) of
             {ok, Delta} ->
@@ -405,7 +391,7 @@ handle_call({update, Key, Operation}, _From, #state{actor=Actor}=State) ->
     {reply, Result, State};
 
 handle_call(memory, _From, State) ->
-    ldb_util:qs("DELTA BACKEND memory"),
+    %ldb_util:qs("DELTA BACKEND memory"),
     FoldFunction = fun({_Key, Value}, {C, R}) ->
         {CRDT, Sequence, DeltaBuffer, AckMap} = Value,
         CRDTSize = ldb_util:size(crdt, CRDT),
@@ -422,12 +408,11 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast({add_key_to_shrink, Key}, #state{keys_to_shrink=Keys}=State) ->
-    ldb_util:qs("DELTA BACKEND add_key_to_shrink"),
+    %ldb_util:qs("DELTA BACKEND add_key_to_shrink"),
     {noreply, State#state{keys_to_shrink=ordsets:add_element(Key, Keys)}};
 
 handle_cast(dbuffer_shrink, #state{keys_to_shrink=Keys}=State) ->
-    ldb_util:qs("DELTA BACKEND dbuffer_shrink"),
-    ?LOG("- DBUFFER SHRINK"),
+    %ldb_util:qs("DELTA BACKEND dbuffer_shrink"),
     case ordsets:size(Keys) > 0 of
         true ->
             Peers = ldb_whisperer:members(),
@@ -475,7 +460,6 @@ handle_cast(dbuffer_shrink, #state{keys_to_shrink=Keys}=State) ->
             ok
     end,
 
-    ?LOG("+ DBUFFER SHRINK"),
     schedule_dbuffer_shrink(),
     {noreply, State#state{keys_to_shrink=ordsets:new()}};
 

--- a/src/ldb_ets_store.erl
+++ b/src/ldb_ets_store.erl
@@ -81,14 +81,17 @@ init([]) ->
     {ok, #state{ets_id=ETS}}.
 
 handle_call(keys, _From, #state{ets_id=ETS}=State) ->
+    ldb_util:qs("STORE keys"),
     Result = keys(ETS),
     {reply, Result, State};
 
 handle_call({get, Key}, _From, #state{ets_id=ETS}=State) ->
+    ldb_util:qs("STORE get"),
     Result = do_get(Key, ETS),
     {reply, Result, State};
 
 handle_call({update, Key, Function}, _From, #state{ets_id=ETS}=State) ->
+    ldb_util:qs("STORE update/2"),
     Result = case do_get(Key, ETS) of
         {ok, Value} ->
             case Function(Value) of
@@ -105,6 +108,7 @@ handle_call({update, Key, Function}, _From, #state{ets_id=ETS}=State) ->
     {reply, Result, State};
 
 handle_call({update, Key, Function, Default}, _From, #state{ets_id=ETS}=State) ->
+    ldb_util:qs("STORE update/3"),
     Value = case do_get(Key, ETS) of
         {ok, V} ->
             V;
@@ -123,6 +127,7 @@ handle_call({update, Key, Function, Default}, _From, #state{ets_id=ETS}=State) -
     {reply, Result, State};
 
 handle_call({update_all, Function}, _From, #state{ets_id=ETS}=State) ->
+    ldb_util:qs("STORE update_all"),
     Keys = keys(ETS),
 
     lists:foreach(
@@ -143,6 +148,7 @@ handle_call({update_all, Function}, _From, #state{ets_id=ETS}=State) ->
     {reply, Result,  State};
 
 handle_call({fold, Function, Acc}, _From, #state{ets_id=ETS}=State) ->
+    ldb_util:qs("STORE fold"),
     Result = ets:foldl(Function, Acc, ETS),
     {reply, Result, State};
 

--- a/src/ldb_listener.erl
+++ b/src/ldb_listener.erl
@@ -51,6 +51,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast(Message, State) ->
+    ldb_util:qs("LISTENER message cast"),
     MessageHandler = ldb_backend:message_handler(Message),
     {MicroSeconds, _Result} = timer:tc(
         MessageHandler,

--- a/src/ldb_listener.erl
+++ b/src/ldb_listener.erl
@@ -51,8 +51,6 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast(Message, State) ->
-    %lager:info("LISTENER HANDLING ~p\n", [Message]),
-
     MessageHandler = ldb_backend:message_handler(Message),
     {MicroSeconds, _Result} = timer:tc(
         MessageHandler,
@@ -61,8 +59,6 @@ handle_cast(Message, State) ->
 
     %% record latency applying this message
     ldb_metrics:record_latency(remote, MicroSeconds),
-
-    %lager:info("LISTENER ENDED HANDLING ~p\n", [Message]),
 
     {noreply, State}.
 

--- a/src/ldb_listener.erl
+++ b/src/ldb_listener.erl
@@ -51,7 +51,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast(Message, State) ->
-    lager:info("LISTENER HANDLING ~p\n", [Message]),
+    %lager:info("LISTENER HANDLING ~p\n", [Message]),
 
     MessageHandler = ldb_backend:message_handler(Message),
     {MicroSeconds, _Result} = timer:tc(
@@ -62,7 +62,7 @@ handle_cast(Message, State) ->
     %% record latency applying this message
     ldb_metrics:record_latency(remote, MicroSeconds),
 
-    lager:info("LISTENER ENDED HANDLING ~p\n", [Message]),
+    %lager:info("LISTENER ENDED HANDLING ~p\n", [Message]),
 
     {noreply, State}.
 

--- a/src/ldb_listener.erl
+++ b/src/ldb_listener.erl
@@ -51,6 +51,8 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast(Message, State) ->
+    lager:info("LISTENER HANDLING ~p\n", [Message]),
+
     MessageHandler = ldb_backend:message_handler(Message),
     {MicroSeconds, _Result} = timer:tc(
         MessageHandler,
@@ -59,6 +61,8 @@ handle_cast(Message, State) ->
 
     %% record latency applying this message
     ldb_metrics:record_latency(remote, MicroSeconds),
+
+    lager:info("LISTENER ENDED HANDLING ~p\n", [Message]),
 
     {noreply, State}.
 

--- a/src/ldb_listener.erl
+++ b/src/ldb_listener.erl
@@ -51,7 +51,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast(Message, State) ->
-    ldb_util:qs("LISTENER message cast"),
+    %ldb_util:qs("LISTENER message cast"),
     MessageHandler = ldb_backend:message_handler(Message),
     {MicroSeconds, _Result} = timer:tc(
         MessageHandler,

--- a/src/ldb_listener.erl
+++ b/src/ldb_listener.erl
@@ -51,7 +51,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast(Message, State) ->
-    %ldb_util:qs("LISTENER message cast"),
+    ldb_util:qs("LISTENER message cast"),
     MessageHandler = ldb_backend:message_handler(Message),
     {MicroSeconds, _Result} = timer:tc(
         MessageHandler,

--- a/src/ldb_pure_op_based_backend.erl
+++ b/src/ldb_pure_op_based_backend.erl
@@ -106,7 +106,11 @@ init([]) ->
 
 handle_call({create, Key, LDBType}, _From, State) ->
     Bottom = ldb_util:new_crdt(type, LDBType),
-    Result = ldb_store:create(Key, Bottom),
+    Result = ldb_store:update(
+        Key,
+        fun(V) -> {ok, V} end,
+        Bottom
+    ),
     {reply, Result, State};
 
 handle_call({query, Key}, _From, State) ->

--- a/src/ldb_state_based_backend.erl
+++ b/src/ldb_state_based_backend.erl
@@ -66,7 +66,9 @@ message_maker() ->
         Actor = ldb_config:id(),
         ShouldStart = Actor < NodeName,
 
-        case ldb_config:get(ldb_driven_mode) of
+        Mode = ldb_config:get(ldb_driven_mode),
+
+        case Mode of
             none ->
                 %% send local state
                 Message = {
@@ -75,48 +77,32 @@ message_maker() ->
                     CRDT
                 },
                 {Message, CRDT};
-            state_driven ->
+            _ ->
                 case ShouldStart of
                     true ->
-                        %% send local state
-                        Message = {
-                            Key,
-                            state_driven,
-                            Actor,
-                            CRDT
-                        },
-                        {Message, CRDT};
-                    false ->
-                        {nothing, CRDT}
-                end;
-            digest_driven ->
-                case ShouldStart of
-                    true ->
-                        %% compute digest
+                        %% compute bottom
                         Bottom = ldb_util:new_crdt(state, CRDT),
 
-                        %% this can be a digest or a CRDT state
-                        Message = case Type:digest(CRDT) of
-                            {state, CRDT} ->
-                                %% use state_driven and
-                                %% send local state
-                                {
-                                    Key,
-                                    state_driven,
-                                    Actor,
-                                    CRDT
-                                };
-                            {mdata, Digest} ->
-                                %% send digest
-                                {
-                                    Key,
-                                    digest_driven,
-                                    Actor,
-                                    Bottom,
-                                    Digest
-                                }
+                        %% compute digest
+                        Digest = case Mode of
+                            state_driven ->
+                                {state, CRDT};
+                            digest_driven ->
+                                %% this can still be a CRDT state
+                                %% if implemented like that
+                                %% by the data type
+                                Type:digest(CRDT)
                         end,
+
+                        Message = {
+                            Key,
+                            digest,
+                            Actor,
+                            Bottom,
+                            Digest
+                        },
                         {Message, CRDT};
+
                     false ->
                         {nothing, CRDT}
                 end
@@ -140,65 +126,64 @@ message_handler({_, state, _}) ->
             end
         )
     end;
-message_handler({_, state_driven, _, _}) ->
-    fun({Key, state_driven, From, {Type, _}=RemoteCRDT}) ->
+message_handler({_, digest, _, _, _}) ->
+    fun({Key, digest, From, {Type, _}=Bottom, Remote) ->
 
         %% create bottom entry
-        Bottom = ldb_util:new_crdt(state, RemoteCRDT),
         ldb_store:create(Key, Bottom),
 
         ldb_store:update(
             Key,
             fun(LocalCRDT) ->
                 %% compute delta
-                Delta = Type:delta(LocalCRDT, {state, RemoteCRDT}),
+                Delta = Type:delta(LocalCRDT, CRDTOrDigest),
 
-                %% send delta
-                Message = {
-                    Key,
-                    state,
-                    Delta
-                },
-                ldb_whisperer:send(From, Message),
+                {ToSend, Updated} = case CRDTOrDigest of
+                    {state, RemoteCRDT} ->
 
-                %% merge received state
-                Merged = Type:merge(LocalCRDT, RemoteCRDT),
-                {ok, Merged}
+                        %% send delta
+                        Message = {
+                            Key,
+                            state,
+                            Delta
+                        },
+
+                        %% merge received state
+                        Merged = Type:merge(LocalCRDT, RemoteCRDT),
+
+                        {Message, Merged};
+
+                    {mdata, Digest} ->
+
+                        LocalDigest = Type:digest(LocalCRDT),
+
+                        Actor = ldb_config:id(),
+                        Message = {
+                            Key,
+                            digest_and_state,
+                            Actor,
+                            Delta,
+                            LocalDigest
+                        },
+
+                        {Message, LocalCRDT}
+                end,
+
+                ldb_whisperer:send(From, ToSend),
+                {ok, Updated}
             end
         )
     end;
-message_handler({_, digest_driven, _, _, _}) ->
-    fun({Key, digest_driven, From, {Type, _}=Bottom, RemoteDigest}) ->
-
-        %% create bottom entry
-        ldb_store:create(Key, Bottom),
-
-        %% compute delta and digest
-        {ok, LocalCRDT} = ldb_store:get(Key),
-        LocalDelta = Type:delta(LocalCRDT, {mdata, RemoteDigest}),
-        {mdata, LocalDigest} = Type:digest(LocalCRDT),
-
-        %% send delta and digest
-        Actor = ldb_config:id(),
-        Message = {
-            Key,
-            digest_driven_with_state,
-            Actor,
-            LocalDelta,
-            LocalDigest
-        },
-        ldb_whisperer:send(From, Message)
-    end;
-message_handler({_, digest_driven_with_state, _, _, _}) ->
-    fun({Key, digest_driven_with_state, From, {Type, _}=RemoteDelta,
+message_handler({_, digest_and_state, _, _, _}) ->
+    fun({Key, digest_and_state, From, {Type, _}=RemoteDelta,
          RemoteDigest}) ->
 
         ldb_store:update(
             Key,
             fun(LocalCRDT) ->
                 %% compute delta
-                LocalDelta = Type:delta(LocalCRDT,
-                                        {mdata, RemoteDigest}),
+                LocalDelta = Type:delta(LocalCRDT, RemoteDigest),
+
                 %% send delta
                 Message = {
                     Key,

--- a/src/ldb_state_based_backend.erl
+++ b/src/ldb_state_based_backend.erl
@@ -127,7 +127,7 @@ message_handler({_, state, _}) ->
         )
     end;
 message_handler({_, digest, _, _, _}) ->
-    fun({Key, digest, From, {Type, _}=Bottom, Remote) ->
+    fun({Key, digest, From, {Type, _}=Bottom, Remote}) ->
 
         %% create bottom entry
         ldb_store:create(Key, Bottom),
@@ -136,9 +136,9 @@ message_handler({_, digest, _, _, _}) ->
             Key,
             fun(LocalCRDT) ->
                 %% compute delta
-                Delta = Type:delta(LocalCRDT, CRDTOrDigest),
+                Delta = Type:delta(LocalCRDT, Remote),
 
-                {ToSend, Updated} = case CRDTOrDigest of
+                {ToSend, Updated} = case Remote of
                     {state, RemoteCRDT} ->
 
                         %% send delta
@@ -153,7 +153,7 @@ message_handler({_, digest, _, _, _}) ->
 
                         {Message, Merged};
 
-                    {mdata, Digest} ->
+                    {mdata, _} ->
 
                         LocalDigest = Type:digest(LocalCRDT),
 

--- a/src/ldb_store.erl
+++ b/src/ldb_store.erl
@@ -26,8 +26,8 @@
 -export([start_link/0,
          keys/0,
          get/1,
-         create/2,
          update/2,
+         update/3,
          update_all/1,
          fold/2]).
 
@@ -37,12 +37,12 @@
 %% @doc Returns the value associated with a given `key()'.
 -callback get(key()) -> {ok, value()} | not_found().
 
-%% @doc Creates a `key()' in store with `value()', if the key
-%%      is not already present in the store.
--callback create(key(), value()) -> ok.
-
 %% @doc Applies a given `function()' to a given `key()'.
 -callback update(key(), function()) -> ok | not_found() | error().
+
+%% @doc Applies a given `function()' to a given `key()'.
+%%      If key not present, use the default `value()'.
+-callback update(key(), function(), value()) -> ok | error().
 
 %% @doc Applies a given `function()' to all `key()'s.
 -callback update_all(function()) -> ok.
@@ -64,13 +64,13 @@ keys() ->
 get(Key) ->
     do(get, [Key]).
 
--spec create(key(), value()) -> ok.
-create(Key, Value) ->
-    do(create, [Key, Value]).
-
 -spec update(key(), function()) -> ok | not_found() | error.
 update(Key, Function) ->
     do(update, [Key, Function]).
+
+-spec update(key(), function(), value()) -> ok | error.
+update(Key, Function, Default) ->
+    do(update, [Key, Function, Default]).
 
 -spec update_all(function()) -> ok.
 update_all(Function) ->

--- a/src/ldb_util.erl
+++ b/src/ldb_util.erl
@@ -30,7 +30,7 @@
          unix_timestamp/0,
          size/2]).
 
--export([qs/1]).
+%-export([qs/1]).
 
 %% @doc Creates a bottom CRDT from a type
 %%      or from an existing state-based CRDT.
@@ -133,6 +133,6 @@ types_map() ->
              {twopset, {state_twopset, pure_twopset}}],
     orddict:from_list(Types).
 
-qs(ID) ->
-    {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
-    lager:info("MAILBOX - " ++ ID ++ " - REMAINING: ~p", [MessageQueueLen]).
+%qs(ID) ->
+%    {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
+%    lager:info("MAILBOX - " ++ ID ++ " - REMAINING: ~p", [MessageQueueLen]).

--- a/src/ldb_util.erl
+++ b/src/ldb_util.erl
@@ -30,6 +30,8 @@
          unix_timestamp/0,
          size/2]).
 
+-export([qs/1]).
+
 %% @doc Creates a bottom CRDT from a type
 %%      or from an existing state-based CRDT.
 new_crdt(type, CType) ->
@@ -130,3 +132,7 @@ types_map() ->
              {pncounter, {state_pncounter, undefined}},
              {twopset, {state_twopset, pure_twopset}}],
     orddict:from_list(Types).
+
+qs(ID) ->
+    {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
+    lager:info("MAILBOX - " ++ ID ++ " - REMAINING: ~p", [MessageQueueLen]).

--- a/src/ldb_util.erl
+++ b/src/ldb_util.erl
@@ -30,7 +30,7 @@
          unix_timestamp/0,
          size/2]).
 
-%-export([qs/1]).
+-export([qs/1]).
 
 %% @doc Creates a bottom CRDT from a type
 %%      or from an existing state-based CRDT.
@@ -133,6 +133,6 @@ types_map() ->
              {twopset, {state_twopset, pure_twopset}}],
     orddict:from_list(Types).
 
-%qs(ID) ->
-%    {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
-%    lager:info("MAILBOX - " ++ ID ++ " - REMAINING: ~p", [MessageQueueLen]).
+qs(ID) ->
+    {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
+    lager:info("MAILBOX - " ++ ID ++ " - REMAINING: ~p", [MessageQueueLen]).

--- a/src/ldb_util.erl
+++ b/src/ldb_util.erl
@@ -134,7 +134,7 @@ types_map() ->
     orddict:from_list(Types).
 
 %% @doc Log Process queue length.
-qs(ID) ->
+qs(_ID) ->
     %{message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
     %lager:info("MAILBOX - " ++ ID ++ " - REMAINING: ~p", [MessageQueueLen]).
     ok.

--- a/src/ldb_util.erl
+++ b/src/ldb_util.erl
@@ -133,6 +133,8 @@ types_map() ->
              {twopset, {state_twopset, pure_twopset}}],
     orddict:from_list(Types).
 
+%% @doc Log Process queue length.
 qs(ID) ->
-    {message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
-    lager:info("MAILBOX - " ++ ID ++ " - REMAINING: ~p", [MessageQueueLen]).
+    %{message_queue_len, MessageQueueLen} = process_info(self(), message_queue_len),
+    %lager:info("MAILBOX - " ++ ID ++ " - REMAINING: ~p", [MessageQueueLen]).
+    ok.

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -83,18 +83,23 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 handle_info(state_sync, State) ->
-    lager:info("WHISPERER STARTING STATE SYNC\n"),
+    lager:info("WHISPERER STATE SYNC\n"),
     {ok, LDBIds} = ldb_peer_service:members(),
+    lager:info("WHISPERER STATE SYNC 1\n"),
 
     UpdateFunction = fun({Key, Value}) ->
         NewValue = lists:foldl(
             fun(LDBId, CurrentValue) ->
+                lager:info("WHISPERER STATE SYNC 2 ~p\n", [LDBId]),
                 MessageMakerFun = ldb_backend:message_maker(),
+                lager:info("WHISPERER STATE SYNC 3 ~p\n", [LDBId]),
 
                 {MicroSeconds, Result} = timer:tc(
                     MessageMakerFun,
                     [Key, CurrentValue, LDBId]
                 ),
+
+                lager:info("WHISPERER STATE SYNC 4 ~p\n", [LDBId]),
 
                 {Message, UpdatedValue} = Result,
 
@@ -105,10 +110,12 @@ handle_info(state_sync, State) ->
                     _ ->
                         do_send(LDBId, Message)
                 end,
+                lager:info("WHISPERER STATE SYNC 5 ~p\n", [LDBId]),
 
                 %% record latency creating this message
                 ldb_metrics:record_latency(local, MicroSeconds),
 
+                lager:info("WHISPERER STATE SYNC 6 ~p\n", [LDBId]),
                 UpdatedValue
 
             end,

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -162,10 +162,10 @@ do_send(LDBId, Message) ->
 metrics({_Key, state, CRDT}) ->
     M = {state, ldb_util:size(crdt, CRDT)},
     record_message([M]);
-metrics({_Key, digest, _From, {state, CRDT}}) ->
+metrics({_Key, digest, _From, _Bottom, {state, CRDT}}) ->
     M = {state, ldb_util:size(crdt, CRDT)},
     record_message([M]);
-metrics({_Key, digest, _From, {mdata, Digest}}) ->
+metrics({_Key, digest, _From, _Bottom, {mdata, Digest}}) ->
     M = {digest, ldb_util:size(term, Digest)},
     record_message([M]);
 metrics({_Key, digest_and_state, _From, Delta, {mdata, Digest}}) ->

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -84,7 +84,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast({update_membership, Membership}, State) ->
-    Members = [Name || {Name, _, _} <- Membership, Name /= ldb_config:id()],
+    Members = [Name || {Name, _, _} <- sets:to_list(Membership), Name /= ldb_config:id()],
 
     ?LOG("NEW MEMBERS ~p\n", [Members]),
 

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -83,6 +83,7 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 handle_info(state_sync, State) ->
+    lager:info("WHISPERER STARTING STATE SYNC\n"),
     {ok, LDBIds} = ldb_peer_service:members(),
 
     UpdateFunction = fun({Key, Value}) ->
@@ -119,6 +120,7 @@ handle_info(state_sync, State) ->
     end,
 
     ldb_store:update_all(UpdateFunction),
+    lager:info("WHISPERER ENDING STATE SYNC\n"),
     schedule_state_sync(),
     {noreply, State};
 
@@ -140,6 +142,7 @@ schedule_state_sync() ->
 %% @private
 -spec do_send(ldb_node_id(), term()) -> ok.
 do_send(LDBId, Message) ->
+    lager:info("WHISPERER SENDING MESSAGE ~p TO ~p\n", [Message, LDBId]),
 
     %% try to send the message
     Result = ldb_peer_service:forward_message(
@@ -156,6 +159,7 @@ do_send(LDBId, Message) ->
             ?LOG("Error trying to send message ~p to node ~p. Reason ~p",
                  [Message, LDBId, Error])
     end,
+    lager:info("WHISPERER DONE SENDING MESSAGE ~p TO ~p\n", [Message, LDBId]),
     ok.
 
 %% @private

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -162,13 +162,13 @@ do_send(LDBId, Message) ->
 metrics({_Key, state, CRDT}) ->
     M = {state, ldb_util:size(crdt, CRDT)},
     record_message([M]);
-metrics({_Key, state_driven, _From, Delta}) ->
-    M = {state, ldb_util:size(crdt, Delta)},
+metrics({_Key, digest, _From, {state, CRDT}}) ->
+    M = {state, ldb_util:size(crdt, CRDT)},
     record_message([M]);
-metrics({_Key, digest_driven, _From, _Bottom, Digest}) ->
+metrics({_Key, digest, _From, {mdata, Digest}}) ->
     M = {digest, ldb_util:size(term, Digest)},
     record_message([M]);
-metrics({_Key, digest_driven_with_state, _From, Delta, Digest}) ->
+metrics({_Key, digest_and_state, _From, Delta, {mdata, Digest}}) ->
     M1 = {state, ldb_util:size(crdt, Delta)},
     M2 = {digest, ldb_util:size(term, Digest)},
     record_message([M1, M2]);

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -77,7 +77,7 @@ init([]) ->
     {ok, #state{members=[]}}.
 
 handle_call(members, _From, #state{members=Members}=State) ->
-    %ldb_util:qs("WHISPERER members"),
+    ldb_util:qs("WHISPERER members"),
     {reply, Members, State};
 
 handle_call(Msg, _From, State) ->
@@ -85,7 +85,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast({update_membership, Membership}, State) ->
-    %ldb_util:qs("WHISPERER update_membership"),
+    ldb_util:qs("WHISPERER update_membership"),
     Members = [Name || {Name, _, _} <- Membership, Name /= ldb_config:id()],
 
     ?LOG("NEW MEMBERS ~p\n", [Members]),
@@ -93,7 +93,7 @@ handle_cast({update_membership, Membership}, State) ->
     {noreply, State#state{members=Members}};
 
 handle_cast({send, LDBId, Message}, State) ->
-    %ldb_util:qs("WHISPERER send"),
+    ldb_util:qs("WHISPERER send"),
     do_send(LDBId, Message),
     {noreply, State};
 
@@ -102,7 +102,7 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 handle_info(state_sync, #state{members=LDBIds}=State) ->
-    %ldb_util:qs("WHISPERER state_sync"),
+    ldb_util:qs("WHISPERER state_sync"),
     UpdateFunction = fun({Key, Value}) ->
         NewValue = lists:foldl(
             fun(LDBId, CurrentValue) ->

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -27,6 +27,7 @@
 %% ldb_whisperer callbacks
 -export([start_link/0,
          members/0,
+         update_membership/1,
          send/2]).
 
 %% gen_server callbacks
@@ -37,7 +38,7 @@
          terminate/2,
          code_change/3]).
 
--record(state, {}).
+-record(state, {members :: list(ldb_node_id())}).
 
 -spec start_link() -> {ok, pid()} | ignore | {error, term()}.
 start_link() ->
@@ -46,6 +47,10 @@ start_link() ->
 -spec members() -> list(ldb_node_id()).
 members() ->
     gen_server:call(?MODULE, members, infinity).
+
+-spec update_membership(list(node_spec())) -> ok.
+update_membership(Membership) ->
+    gen_server:cast(?MODULE, {update_membership, Membership}).
 
 -spec send(ldb_node_id(), term()) -> ok.
 send(LDBId, Message) ->
@@ -62,17 +67,28 @@ init([]) ->
             ok
     end,
 
-    ?LOG("ldb_whisperer initialized!"),
-    {ok, #state{}}.
+    %% configure membership callback
+    MembershipFun = fun(Membership) ->
+        ldb_whisperer:update_membership(Membership)
+    end,
+    partisan_peer_service:add_sup_callback(MembershipFun),
 
-handle_call(members, _From, State) ->
-    %% @todo ldb_peer_service should cache members using partisan add_sup_callback
-    {ok, Result} = ldb_peer_service:members(),
-    {reply, Result, State};
+    ?LOG("ldb_whisperer initialized!"),
+    {ok, #state{members=[]}}.
+
+handle_call(members, _From, #state{members=Members}=State) ->
+    {reply, Members, State};
 
 handle_call(Msg, _From, State) ->
     lager:warning("Unhandled call message: ~p", [Msg]),
     {noreply, State}.
+
+handle_cast({update_membership, Membership}, State) ->
+    Members = [Name || {Name, _, _} <- Membership, Name /= ldb_config:id()],
+
+    ?LOG("NEW MEMBERS ~p\n", [Members]),
+
+    {noreply, State#state{members=Members}};
 
 handle_cast({send, LDBId, Message}, State) ->
     do_send(LDBId, Message),
@@ -82,11 +98,7 @@ handle_cast(Msg, State) ->
     lager:warning("Unhandled cast message: ~p", [Msg]),
     {noreply, State}.
 
-handle_info(state_sync, State) ->
-    lager:info("WHISPERER STATE SYNC\n"),
-    {ok, LDBIds} = ldb_peer_service:members(),
-    lager:info("WHISPERER STATE SYNC 1\n"),
-
+handle_info(state_sync, #state{members=LDBIds}=State) ->
     UpdateFunction = fun({Key, Value}) ->
         NewValue = lists:foldl(
             fun(LDBId, CurrentValue) ->

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -99,6 +99,7 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 handle_info(state_sync, #state{members=LDBIds}=State) ->
+    lager:info("S: STATE SYNC"),
     UpdateFunction = fun({Key, Value}) ->
         NewValue = lists:foldl(
             fun(LDBId, CurrentValue) ->
@@ -133,6 +134,7 @@ handle_info(state_sync, #state{members=LDBIds}=State) ->
     end,
 
     ldb_store:update_all(UpdateFunction),
+    lager:info("E: STATE SYNC"),
     schedule_state_sync(),
     {noreply, State};
 

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -90,16 +90,12 @@ handle_info(state_sync, State) ->
     UpdateFunction = fun({Key, Value}) ->
         NewValue = lists:foldl(
             fun(LDBId, CurrentValue) ->
-                lager:info("WHISPERER STATE SYNC 2 ~p\n", [LDBId]),
                 MessageMakerFun = ldb_backend:message_maker(),
-                lager:info("WHISPERER STATE SYNC 3 ~p\n", [LDBId]),
 
                 {MicroSeconds, Result} = timer:tc(
                     MessageMakerFun,
                     [Key, CurrentValue, LDBId]
                 ),
-
-                lager:info("WHISPERER STATE SYNC 4 ~p\n", [LDBId]),
 
                 {Message, UpdatedValue} = Result,
 
@@ -110,12 +106,10 @@ handle_info(state_sync, State) ->
                     _ ->
                         do_send(LDBId, Message)
                 end,
-                lager:info("WHISPERER STATE SYNC 5 ~p\n", [LDBId]),
 
                 %% record latency creating this message
                 ldb_metrics:record_latency(local, MicroSeconds),
 
-                lager:info("WHISPERER STATE SYNC 6 ~p\n", [LDBId]),
                 UpdatedValue
 
             end,
@@ -127,7 +121,6 @@ handle_info(state_sync, State) ->
     end,
 
     ldb_store:update_all(UpdateFunction),
-    lager:info("WHISPERER ENDING STATE SYNC\n"),
     schedule_state_sync(),
     {noreply, State};
 
@@ -149,8 +142,6 @@ schedule_state_sync() ->
 %% @private
 -spec do_send(ldb_node_id(), term()) -> ok.
 do_send(LDBId, Message) ->
-    lager:info("WHISPERER SENDING MESSAGE ~p TO ~p\n", [Message, LDBId]),
-
     %% try to send the message
     Result = ldb_peer_service:forward_message(
         LDBId,
@@ -166,7 +157,6 @@ do_send(LDBId, Message) ->
             ?LOG("Error trying to send message ~p to node ~p. Reason ~p",
                  [Message, LDBId, Error])
     end,
-    lager:info("WHISPERER DONE SENDING MESSAGE ~p TO ~p\n", [Message, LDBId]),
     ok.
 
 %% @private

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -77,7 +77,7 @@ init([]) ->
     {ok, #state{members=[]}}.
 
 handle_call(members, _From, #state{members=Members}=State) ->
-    ldb_util:qs("WHISPERER members"),
+    %ldb_util:qs("WHISPERER members"),
     {reply, Members, State};
 
 handle_call(Msg, _From, State) ->
@@ -85,7 +85,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast({update_membership, Membership}, State) ->
-    ldb_util:qs("WHISPERER update_membership"),
+    %ldb_util:qs("WHISPERER update_membership"),
     Members = [Name || {Name, _, _} <- Membership, Name /= ldb_config:id()],
 
     ?LOG("NEW MEMBERS ~p\n", [Members]),
@@ -93,7 +93,7 @@ handle_cast({update_membership, Membership}, State) ->
     {noreply, State#state{members=Members}};
 
 handle_cast({send, LDBId, Message}, State) ->
-    ldb_util:qs("WHISPERER send"),
+    %ldb_util:qs("WHISPERER send"),
     do_send(LDBId, Message),
     {noreply, State};
 
@@ -102,8 +102,7 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 handle_info(state_sync, #state{members=LDBIds}=State) ->
-    ldb_util:qs("WHISPERER state_sync"),
-    lager:info("- STATE SYNC"),
+    %ldb_util:qs("WHISPERER state_sync"),
     UpdateFunction = fun({Key, Value}) ->
         NewValue = lists:foldl(
             fun(LDBId, CurrentValue) ->
@@ -138,7 +137,6 @@ handle_info(state_sync, #state{members=LDBIds}=State) ->
     end,
 
     ldb_store:update_all(UpdateFunction),
-    lager:info("+ STATE SYNC"),
     schedule_state_sync(),
     {noreply, State};
 

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -77,6 +77,7 @@ init([]) ->
     {ok, #state{members=[]}}.
 
 handle_call(members, _From, #state{members=Members}=State) ->
+    ldb_util:qs("WHISPERER members"),
     {reply, Members, State};
 
 handle_call(Msg, _From, State) ->
@@ -84,6 +85,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast({update_membership, Membership}, State) ->
+    ldb_util:qs("WHISPERER update_membership"),
     Members = [Name || {Name, _, _} <- Membership, Name /= ldb_config:id()],
 
     ?LOG("NEW MEMBERS ~p\n", [Members]),
@@ -91,6 +93,7 @@ handle_cast({update_membership, Membership}, State) ->
     {noreply, State#state{members=Members}};
 
 handle_cast({send, LDBId, Message}, State) ->
+    ldb_util:qs("WHISPERER send"),
     do_send(LDBId, Message),
     {noreply, State};
 
@@ -99,7 +102,8 @@ handle_cast(Msg, State) ->
     {noreply, State}.
 
 handle_info(state_sync, #state{members=LDBIds}=State) ->
-    lager:info("S: STATE SYNC"),
+    ldb_util:qs("WHISPERER state_sync"),
+    lager:info("- STATE SYNC"),
     UpdateFunction = fun({Key, Value}) ->
         NewValue = lists:foldl(
             fun(LDBId, CurrentValue) ->
@@ -134,7 +138,7 @@ handle_info(state_sync, #state{members=LDBIds}=State) ->
     end,
 
     ldb_store:update_all(UpdateFunction),
-    lager:info("E: STATE SYNC"),
+    lager:info("+ STATE SYNC"),
     schedule_state_sync(),
     {noreply, State};
 

--- a/src/ldb_whisperer.erl
+++ b/src/ldb_whisperer.erl
@@ -84,7 +84,7 @@ handle_call(Msg, _From, State) ->
     {noreply, State}.
 
 handle_cast({update_membership, Membership}, State) ->
-    Members = [Name || {Name, _, _} <- sets:to_list(Membership), Name /= ldb_config:id()],
+    Members = [Name || {Name, _, _} <- Membership, Name /= ldb_config:id()],
 
     ?LOG("NEW MEMBERS ~p\n", [Members]),
 


### PR DESCRIPTION
- When a node knows nothing about a peer or the information present in the delta buffer is in the future of the last known update seen by that peer, use `state_driven` or `digest_driven` algorithms to synchronize the two replicas